### PR TITLE
feat: 유저와 명함 엔티티 분리 및 개인정보 공개 여부 필드 추가

### DIFF
--- a/src/main/java/com/namecard/config/SecurityConfig.java
+++ b/src/main/java/com/namecard/config/SecurityConfig.java
@@ -51,10 +51,9 @@ public class SecurityConfig {
                 , "/swagger-resources/**"
                 , "/swagger-ui/**"
                 , "/v2/api-docs"
-                , "/api/member/join"
-                , "/api/member/login"
-                , "/api/member/passwdReset"
-                , "/api/auth/refresh"
+                , "/api/member/sign-up"
+                , "/api/member/sign-in"
+                , "/api/auth/renew"
                 , "/api/auth/sendAuth"
                 , "/api/auth/validAuth"
                 , "/api/tag/**"
@@ -99,7 +98,7 @@ public class SecurityConfig {
     }
 
     @Bean
-    public PasswordEncoder passwordEncoder(){
+    public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
     }
 }

--- a/src/main/java/com/namecard/indicator/repository/impl/IndicatorRepositoryImpl.java
+++ b/src/main/java/com/namecard/indicator/repository/impl/IndicatorRepositoryImpl.java
@@ -1,11 +1,11 @@
 package com.namecard.indicator.repository.impl;
 
-import com.namecard.indicator.dto.entity.QIndicator;
-import com.namecard.indicator.dto.entity.QIndicatorConnect;
+import com.namecard.indicator.domain.QIndicator;
+import com.namecard.indicator.domain.QIndicatorConnect;
 import com.namecard.indicator.dto.result.IndicatorInfoResult.IndicatorScoreResult;
 import com.namecard.indicator.dto.result.MyIndicatorInfoResult;
 import com.namecard.indicator.repository.IndicatorQuerydslRepository;
-import com.namecard.tag.dto.entity.QTag;
+import com.namecard.tag.domain.QTag;
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
@@ -18,6 +18,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class IndicatorRepositoryImpl implements IndicatorQuerydslRepository {
     private final JPAQueryFactory jpaQueryFactory;
+
     @Override
     public List<IndicatorScoreResult> findIndicatorScoreByMemberId(long userId) {
         QIndicator qindicator = QIndicator.indicator;
@@ -28,10 +29,10 @@ public class IndicatorRepositoryImpl implements IndicatorQuerydslRepository {
                         qindicator.tagScore.avg()))
                 .from(qIndicatorConnect)
                 .innerJoin(qTag)
-                    .on(qIndicatorConnect.tagId.eq(qTag.tagId))
+                .on(qIndicatorConnect.tagId.eq(qTag.tagId))
                 .leftJoin(qindicator)
-                    .on(qIndicatorConnect.tagId.eq(qindicator.tagId)
-                    .and(qIndicatorConnect.memberId.eq(qindicator.memberId)))
+                .on(qIndicatorConnect.tagId.eq(qindicator.tagId)
+                        .and(qIndicatorConnect.memberId.eq(qindicator.memberId)))
                 .where(qIndicatorConnect.memberId.eq(userId))
                 .groupBy(qTag.tagName)
                 .fetch();
@@ -48,10 +49,10 @@ public class IndicatorRepositoryImpl implements IndicatorQuerydslRepository {
                         qIndicator.tagScore.avg()))
                 .from(qIndicatorConnect)
                 .innerJoin(qTag)
-                    .on(qIndicatorConnect.tagId.eq(qTag.tagId))
+                .on(qIndicatorConnect.tagId.eq(qTag.tagId))
                 .leftJoin(qIndicator)
-                    .on(qIndicatorConnect.memberId.eq(qIndicator.memberId)
-                    .and(qTag.tagId.eq(qIndicator.tagId)))
+                .on(qIndicatorConnect.memberId.eq(qIndicator.memberId)
+                        .and(qTag.tagId.eq(qIndicator.tagId)))
                 .where(qIndicatorConnect.memberId.eq(userId))
                 .groupBy(qIndicatorConnect.tagId, qTag.tagName)
                 .fetch();

--- a/src/main/java/com/namecard/indicator/service/IndicatorService.java
+++ b/src/main/java/com/namecard/indicator/service/IndicatorService.java
@@ -59,8 +59,8 @@ public class IndicatorService {
         IndicatorInfoResult result = IndicatorInfoResult.builder()
                 .email(member.getEmail())
                 .userName(member.getUserName())
-                .phoneNum(member.getPhoneNum())
-                .introduce(member.getIntroduce())
+                .phoneNum(member.getCard().getPhoneNumber())
+                .introduce(member.getCard().getIntroduce())
                 .scoreList(scoreList)
                 .build();
         return result;

--- a/src/main/java/com/namecard/member/controller/MemberApiController.java
+++ b/src/main/java/com/namecard/member/controller/MemberApiController.java
@@ -44,7 +44,7 @@ public class MemberApiController {
 
     @ApiOperation(value = "비밀번호 변경 [엑세스 토큰 필요]")
     @PutMapping("/password")
-    public ApiResult<Boolean> passwdReset(
+    public ApiResult<Boolean> resetPassword(
             @Valid @RequestBody PasswdResetRequest request,
             @ApiParam(hidden = true) @AuthenticationPrincipal String memberId
     ) {

--- a/src/main/java/com/namecard/member/domain/Card.java
+++ b/src/main/java/com/namecard/member/domain/Card.java
@@ -1,0 +1,58 @@
+package com.namecard.member.domain;
+
+import com.namecard.config.AuditBaseEntity;
+import com.namecard.member.dto.request.MyProfileRequest;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Entity
+@NoArgsConstructor
+@Getter
+public class Card extends AuditBaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY, generator = "card_seq")
+    @Schema(description = "명함 ID")
+    private Long cardId;
+
+    @Schema(description = "명함 공개용 이메일")
+    private String cardEmail;
+
+    @Schema(description = "사용자 전화번호")
+    private String phoneNumber;
+
+    @Schema(description = "자기소개")
+    private String introduce;
+
+    @Schema(description = "이메일 공개 여부")
+    private boolean isPublicEmail;
+
+    @Schema(description = "전화번호 공개 여부")
+    private boolean isPublicPhone;
+
+    @Schema(description = "자기소개 공개 여부")
+    private boolean isPublicIntroduce;
+
+    @Builder
+    public Card(String cardEmail, String phoneNumber, String introduce, boolean isPublicEmail, boolean isPublicPhone, boolean isPublicIntroduce) {
+        this.cardEmail = cardEmail;
+        this.phoneNumber = phoneNumber;
+        this.introduce = introduce;
+        this.isPublicEmail = isPublicEmail;
+        this.isPublicPhone = isPublicPhone;
+        this.isPublicIntroduce = isPublicIntroduce;
+    }
+
+    public void updateCard(MyProfileRequest profileRequest) {
+        this.cardEmail = profileRequest.getEmail();
+        this.phoneNumber = profileRequest.getPhoneNum();
+        this.introduce = profileRequest.getIntroduce();
+        this.isPublicEmail = profileRequest.isPublicEmail();
+        this.isPublicPhone = profileRequest.isPublicPhone();
+        this.isPublicIntroduce = profileRequest.isPublicIntroduce();
+    }
+}

--- a/src/main/java/com/namecard/member/domain/Member.java
+++ b/src/main/java/com/namecard/member/domain/Member.java
@@ -1,7 +1,6 @@
 package com.namecard.member.domain;
 
 import com.namecard.config.AuditBaseEntity;
-import com.namecard.member.dto.request.MyProfileRequest;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 
@@ -32,23 +31,15 @@ public class Member extends AuditBaseEntity {
     @Schema(description = "로그인 비밀번호")
     private String passwd;
 
-    @Schema(description = "사용자 전화번호")
-    private String phoneNum;
-
     @Schema(description = "로그인 횟수. 로그인시 1씩 증")
     private int loginCount;
 
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @JoinColumn(name = "cardId")
+    private Card card;
+
     @Schema(description = "최종 로그인 일자")
     private LocalDateTime lastLoginDt;
-
-    @Schema(description = "간단한 소개")
-    private String introduce;
-
-    public void updateUsers(MyProfileRequest request) {
-        this.phoneNum = request.getPhoneNum();
-        this.email = request.getEmail();
-        this.introduce = request.getIntroduce();
-    }
 
     public void afterLoginSuccess() {
         this.loginCount++;

--- a/src/main/java/com/namecard/member/dto/request/MyProfileRequest.java
+++ b/src/main/java/com/namecard/member/dto/request/MyProfileRequest.java
@@ -1,5 +1,6 @@
 package com.namecard.member.dto.request;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 
 @Data
@@ -7,4 +8,10 @@ public class MyProfileRequest {
     private String phoneNum;
     private String email;
     private String introduce;
+    @JsonProperty("isPublicEmail")
+    private boolean isPublicEmail;
+    @JsonProperty("isPublicPhone")
+    private boolean isPublicPhone;
+    @JsonProperty("isPublicIntroduce")
+    private boolean isPublicIntroduce;
 }

--- a/src/main/java/com/namecard/member/dto/result/MyProfileResult.java
+++ b/src/main/java/com/namecard/member/dto/result/MyProfileResult.java
@@ -1,5 +1,6 @@
 package com.namecard.member.dto.result;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Data;
@@ -17,13 +18,22 @@ public class MyProfileResult {
     @Schema(description = "사용자 이메일")
     private String email;
 
-    @Schema(description = "사용자 닉네임")
-    private String nickname;
-
     @Schema(description = "사용자 전화번호")
     private String phoneNum;
 
     @Schema(description = "자기소개")
     private String introduce;
+
+    @Schema(description = "이메일 공개 여부")
+    @JsonProperty("isPublicEmail")
+    private boolean isPublicEmail;
+
+    @Schema(description = "전화번호 공개 여부")
+    @JsonProperty("isPublicPhone")
+    private boolean isPublicPhone;
+
+    @Schema(description = "자기소개 공개 여부")
+    @JsonProperty("isPublicIntroduce")
+    private boolean isPublicIntroduce;
 
 }

--- a/src/main/java/com/namecard/member/repository/CardRepository.java
+++ b/src/main/java/com/namecard/member/repository/CardRepository.java
@@ -1,0 +1,7 @@
+package com.namecard.member.repository;
+
+import com.namecard.member.domain.Card;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CardRepository extends JpaRepository<Card, Long> {
+}

--- a/src/main/java/com/namecard/member/repository/MemberRepository.java
+++ b/src/main/java/com/namecard/member/repository/MemberRepository.java
@@ -3,7 +3,9 @@ package com.namecard.member.repository;
 
 import com.namecard.member.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -13,9 +15,11 @@ public interface MemberRepository extends JpaRepository<Member, Long>, MemberQue
 
     Optional<Member> findByEmail(String email);
 
-    Optional<Member> findByPhoneNum(String phoneNum);
+    @Query("SELECT m FROM Member m JOIN FETCH m.card c WHERE c.phoneNumber = :phoneNumber")
+    Optional<Member> findByPhoneNum(@Param("phoneNumber") String phoneNumber);
 
-    List<Member> findByEmailOrPhoneNum(String email, String phoneNum);
+    @Query("SELECT m FROM Member m JOIN FETCH m.card c WHERE  m.email = :email OR c.phoneNumber = :phoneNumber")
+    List<Member> findByEmailOrPhoneNum(@Param("email") String email, @Param("phoneNumber") String phoneNumber);
 
     Optional<Member> findByMemberId(long memberNo);
 


### PR DESCRIPTION
## 관련 이슈
close #15 
## 변경사항
- 명함 엔티티 정의
- 유저와 명함 엔티티 연관관계 추가 (유저에 외래키)
- 패키징 변경에 따른 Qclass 에러 수정
- 연관관계 추가에 따른 비즈니스 로직 수정

